### PR TITLE
Add python-dotenv to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ langchain_anthropic==0.1.19
 langchain_core==0.2.11
 langgraph==0.1.5
 streamlit==1.36.0
+python-dotenv


### PR DESCRIPTION
This PR adds python-dotenv to the requirements.txt file. 

The main application code uses the dotenv module to load environment variables, but it wasn't listed in the requirements. This addition will ensure that anyone setting up the project will automatically install python-dotenv, avoiding the need to install it separately.

I've added it without a specific version number to always pull the latest stable version. If a specific version is preferred, please let me know and I can update the PR accordingly.